### PR TITLE
Included necessary header getopt.h

### DIFF
--- a/src/programmer/Makefile
+++ b/src/programmer/Makefile
@@ -2,8 +2,8 @@ PROGNAMES=prog
 
 OBJS= prog.o AppData.o DeviceData.o Programmer.o fx2.o utils.o usb.o
 
-INC = -I ../libhex -I ../libini
-LIBS = ../libhex/libhex.a ../libini/libini.a -L /usr/local/lib -lusb-1.0
+INC ?= -I ../libhex -I ../libini
+LIBS ?= ../libhex/libhex.a ../libini/libini.a -L /usr/local/lib -lusb-1.0
 
 include ../Makefile.inc
 

--- a/src/programmer/prog.cpp
+++ b/src/programmer/prog.cpp
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <string>
 
+#include "getopt.h"
 #include "usb.h"
 #include "utils.h"
 #include "Programmer.h"


### PR DESCRIPTION
Hello kiml,

I just needed to include the getopt header in order for prog to build on Arch Linux.

Thanks,
Andreas
